### PR TITLE
Bug fix to return array on getBodyParts

### DIFF
--- a/lib/bodydetection.js
+++ b/lib/bodydetection.js
@@ -154,7 +154,7 @@ class Body {
     }
 
     getBodyParts () {
-        return bodyParts
+        return this.bodyParts
     }
 
     getDistanceBetweenBodyParts (first, second) {


### PR DESCRIPTION
Previously returned 'undefined'